### PR TITLE
Add README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Pizzeria La Cannata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Pizzeria La Cannata
+
+A simple PHP application demonstrating a small ordering system with a menu and cart.
+
+## Requirements
+
+- PHP 8.1+ with the PDO MySQL extension
+- A MySQL database with the required tables
+- A web server such as Apache or the built in PHP development server
+
+## Setup
+
+1. Clone the repository or download the source code.
+2. Configure the database connection. You can set the environment variables
+   `DB_HOST`, `DB_NAME`, `DB_USER` and `DB_PASS` or provide a PHP file returning
+   the configuration array.
+   Copy `src/config.sample.php` somewhere outside the web root, adjust the
+   values and set the path in the `DB_CONFIG_FILE` environment variable.
+
+Example configuration file:
+
+```php
+<?php
+return [
+    'db_host' => 'localhost',
+    'db_name' => 'pizzeria',
+    'db_user' => 'user',
+    'db_pass' => 'secret',
+];
+```
+
+## Running the application
+
+From the project root you can start the PHP development server:
+
+```bash
+php -S localhost:8000
+```
+
+Then open <http://localhost:8000> in your browser.
+
+When deploying with Apache make sure mod_rewrite is enabled and that the
+provided `.htaccess` file is used so that all requests are routed to
+`index.php`.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE)
+file for details.
+


### PR DESCRIPTION
## Summary
- add MIT LICENSE
- document setup and running instructions in README

## Testing
- `php -l index.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68826f7119b8832f89ba40905217e55f