### PR TITLE
Remove real DB credentials from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore local configuration file containing real credentials
+src/config.php

--- a/src/config.sample.php
+++ b/src/config.sample.php
@@ -3,8 +3,8 @@
 // update with your real credentials. Then set the path in the DB_CONFIG_FILE
 // environment variable or define the individual DB_* variables.
 return [
-    'db_host' => '31.11.39.237',
-    'db_name' => 'Sql1412226_2',
-    'db_user' => 'Sql1412226',
-    'db_pass' => '6i5067256h',
+    'db_host' => 'localhost',
+    'db_name' => 'example_db',
+    'db_user' => 'example_user',
+    'db_pass' => 'secret',
 ];


### PR DESCRIPTION
## Summary
- remove DB_CONFIG_FILE.php containing real credentials
- add placeholder config.sample.php
- ignore local config.php

## Testing
- `php -l src/config.sample.php`
- `php -l src/Database.php`
- `find src -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68827881daac832f8c14f54e8caf7b48